### PR TITLE
fix: unstack all completion

### DIFF
--- a/CardStackController/Classes/CardStackController.swift
+++ b/CardStackController/Classes/CardStackController.swift
@@ -290,7 +290,7 @@ public class CardStackController: UIViewController {
     ///
     /// - Parameter completion: completion block called after unstacking is complete
     public func unstackAllViewControllers(completion: CompletionBlock? = nil) {
-        unstack(viewControllers: viewControllers)
+        unstack(viewControllers: viewControllers, completion: completion)
     }
 
     /// Unstack viewcontrollers until a given viewcontroller is founded.


### PR DESCRIPTION
The completion block passed to API method `unstackAllViewControllers(completion:)` wasn't getting passed along to private method `unstack(viewControllers:completion:)`, so this is just a minor fix for that.